### PR TITLE
chore(A-02): configure MongoDB Atlas with NestJS config

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,6 +12,7 @@
         "@mongoloquent/core": "^4.0.0",
         "@mongoloquent/nestjs": "^2.0.0",
         "@nestjs/common": "^11.0.1",
+        "@nestjs/config": "^4.0.4",
         "@nestjs/core": "^11.0.1",
         "@nestjs/platform-express": "^11.0.1",
         "mongodb": "^6.21.0",
@@ -2346,6 +2347,33 @@
         "class-validator": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/config": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-4.0.4.tgz",
+      "integrity": "sha512-CJPjNitr0bAufSEnRe2N+JbnVmMmDoo6hvKCPzXgZoGwJSmp/dZPk9f/RMbuD/+Q1ZJPjwsRpq0vxna++Knwow==",
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "17.4.1",
+        "dotenv-expand": "12.0.3",
+        "lodash": "4.18.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "rxjs": "^7.1.0"
+      }
+    },
+    "node_modules/@nestjs/config/node_modules/dotenv": {
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
+      "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/@nestjs/core": {
@@ -4960,6 +4988,21 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/dotenv-expand": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.3.tgz",
+      "integrity": "sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -7374,7 +7417,6 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.memoize": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,12 +18,13 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "poc:verify": "node --env-file=.env -r ts-node/register src/poc/poc.runner.ts"
+    "poc:verify": "node -r ts-node/register src/poc/poc.runner.ts"
   },
   "dependencies": {
     "@mongoloquent/core": "^4.0.0",
     "@mongoloquent/nestjs": "^2.0.0",
     "@nestjs/common": "^11.0.1",
+    "@nestjs/config": "^4.0.4",
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
     "mongodb": "^6.21.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,32 +1,30 @@
 import { Module } from '@nestjs/common';
+import {
+  ConfigModule,
+  ConfigService,
+} from '@nestjs/config';
 import { MongoloquentModule } from '@mongoloquent/nestjs';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { PocModule } from './poc/poc.module';
 
-function getRequiredEnvironment(name: string): string {
-  const value = process.env[name];
-
-  if (!value) {
-    throw new Error(
-      `Environment variable ${name} belum diisi`,
-    );
-  }
-
-  return value;
-}
-
 @Module({
   imports: [
-    MongoloquentModule.forRoot({
-      name: 'default',
-      connection: getRequiredEnvironment(
-        'MONGOLOQUENT_DATABASE_URI',
-      ),
-      database: getRequiredEnvironment(
-        'MONGOLOQUENT_DATABASE_NAME',
-      ),
-      timezone: 'Asia/Jakarta',
+    ConfigModule.forRoot({
+      isGlobal: true,
+    }),
+    MongoloquentModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => ({
+        connection: configService.getOrThrow<string>(
+          'MONGOLOQUENT_DATABASE_URI',
+        ),
+        database: configService.getOrThrow<string>(
+          'MONGOLOQUENT_DATABASE_NAME',
+        ),
+        timezone: 'Asia/Jakarta',
+      }),
       models: [],
       global: true,
     }),


### PR DESCRIPTION
 Yang dikerjakan

- Setup konfigurasi environment di NestJS
- Menghubungkan backend ke MongoDB Atlas
- URI dan nama database diambil dari file env
- Menambahkan env example sebagai panduan untuk tim
- Memastikan env asli tidak ikut ke Git
- Menyesuaikan runner PoC dengan konfigurasi yang baru

 Testing

- Build berhasil
- Koneksi ke MongoDB Atlas berhasil
- PoC Mongoloquent masih berjalan