### PR TITLE
feat(B-01): add facility blood request creation

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -5,6 +5,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { PocModule } from './poc/poc.module';
 import { AuthModule } from './auth/auth.module';
+import { BloodsModule } from './bloods/bloods.module';
 
 @Module({
   imports: [
@@ -28,6 +29,7 @@ import { AuthModule } from './auth/auth.module';
     }),
     PocModule,
     AuthModule,
+    BloodsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/bloods/bloods.controller.ts
+++ b/backend/src/bloods/bloods.controller.ts
@@ -1,0 +1,30 @@
+import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import type { Request } from 'express';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import type { AuthenticatedUser } from '../auth/interfaces/jwt-payload.interface';
+import { BloodsService } from './bloods.service';
+import { CreateBloodDto } from './dto/create-blood.dto';
+
+interface AuthenticatedRequest extends Request {
+  user: AuthenticatedUser;
+}
+
+@Controller('bloods')
+export class BloodsController {
+  constructor(private readonly bloodsService: BloodsService) {}
+
+  @Post()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('facility')
+  create(
+    @Req() request: AuthenticatedRequest,
+    @Body() createBloodDto: CreateBloodDto,
+  ) {
+    return this.bloodsService.createForFacility(
+      request.user.userId,
+      createBloodDto,
+    );
+  }
+}

--- a/backend/src/bloods/bloods.module.ts
+++ b/backend/src/bloods/bloods.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { MongoloquentModule } from '@mongoloquent/nestjs';
+import { AuthModule } from '../auth/auth.module';
+import { Hospital } from '../hospitals/entities/hospital.model';
+import { BloodsController } from './bloods.controller';
+import { BloodsService } from './bloods.service';
+import { Blood } from './entities/blood.model';
+
+@Module({
+  imports: [MongoloquentModule.forFeature([Blood, Hospital]), AuthModule],
+  controllers: [BloodsController],
+  providers: [BloodsService],
+})
+export class BloodsModule {}

--- a/backend/src/bloods/bloods.service.ts
+++ b/backend/src/bloods/bloods.service.ts
@@ -1,0 +1,64 @@
+import {
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { InjectModel } from '@mongoloquent/nestjs';
+import { ObjectId } from 'mongodb';
+import { Hospital } from '../hospitals/entities/hospital.model';
+import { CreateBloodDto } from './dto/create-blood.dto';
+import { Blood } from './entities/blood.model';
+
+@Injectable()
+export class BloodsService {
+  constructor(
+    @InjectModel(Blood)
+    private readonly bloodModel: Blood,
+
+    @InjectModel(Hospital)
+    private readonly hospitalModel: Hospital,
+  ) {}
+
+  async createForFacility(userId: string, createBloodDto: CreateBloodDto) {
+    if (!ObjectId.isValid(userId)) {
+      throw new UnauthorizedException('Invalid authenticated user');
+    }
+
+    const hospital = await this.hospitalModel
+      .where(`user_id`, new ObjectId(userId))
+      .first();
+
+    if (!hospital) {
+      throw new NotFoundException(
+        'Hospital profile was not found for this facility',
+      );
+    }
+
+    const createdAt = new Date();
+    const schedule = new Date(createBloodDto.schedule);
+
+    const blood = await this.bloodModel.insert({
+      hospitals_id: hospital._id,
+      blood_type: createBloodDto.blood_type,
+      rhesus: createBloodDto.rhesus,
+      quantity: createBloodDto.quantity,
+      status_blood: createBloodDto.status_blood,
+      schedule,
+      created_at: createdAt,
+    });
+
+    return {
+      success: true,
+      data: {
+        id: blood._id.toString(),
+        hospitals_id: blood.hospitals_id.toString(),
+        blood_type: blood.blood_type,
+        rhesus: blood.rhesus,
+        quantity: blood.quantity,
+        status_blood: blood.status_blood,
+        schedule: blood.schedule,
+        created_at: blood.created_at,
+      },
+    };
+  }
+}

--- a/backend/src/bloods/dto/create-blood.dto.ts
+++ b/backend/src/bloods/dto/create-blood.dto.ts
@@ -1,0 +1,35 @@
+import { Type } from 'class-transformer';
+import { IsDateString, IsIn, IsInt, Min } from 'class-validator';
+import {
+  BLOOD_STATUSES,
+  BLOOD_TYPES,
+  RHESUS_TYPES,
+} from '../../common/constants';
+import type {
+  BloodStatus,
+  BloodType,
+  RhesusType,
+} from '../../common/constants';
+
+const CREATEABLE_BLOOD_STATUSES = BLOOD_STATUSES.filter(
+  (status) => status !== 'closed',
+);
+
+export class CreateBloodDto {
+  @IsIn(BLOOD_TYPES)
+  blood_type!: BloodType;
+
+  @IsIn(RHESUS_TYPES)
+  rhesus!: RhesusType;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  quantity!: number;
+
+  @IsDateString()
+  schedule!: string;
+
+  @IsIn(CREATEABLE_BLOOD_STATUSES)
+  status_blood!: BloodStatus;
+}


### PR DESCRIPTION
## Summary

- Add `POST /bloods` for authenticated facilities
- Validate blood request payload using DTO
- Resolve `hospitals_id` from authenticated facility
- Protect endpoint using JWT and facility role guards
- Return consistent success response

## Verification

- `npm run build` ✅
- `npm test -- --runInBand` ✅
- Targeted ESLint check ✅
- Facility create request → 201 ✅
- Without token → 401 ✅
- Donor token → 403 ✅
- Invalid payload → 400 ✅
- Facility without hospital → 404 ✅
- Data verified in MongoDB Atlas ✅

## Scope

Task B-01 only. No changes to shared models, authentication implementation, dependencies, or environment configuration.