### PR TITLE
feat(B-02): add blood list detail and close endpoints

### DIFF
--- a/backend/src/bloods/bloods.controller.ts
+++ b/backend/src/bloods/bloods.controller.ts
@@ -1,4 +1,13 @@
-import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Post,
+  Req,
+  UseGuards,
+  Get,
+  Param,
+  Patch,
+} from '@nestjs/common';
 import type { Request } from 'express';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
@@ -6,6 +15,7 @@ import { RolesGuard } from '../auth/guards/roles.guard';
 import type { AuthenticatedUser } from '../auth/interfaces/jwt-payload.interface';
 import { BloodsService } from './bloods.service';
 import { CreateBloodDto } from './dto/create-blood.dto';
+import { BloodIdParamDto } from './dto/blood-id-param.dto';
 
 interface AuthenticatedRequest extends Request {
   user: AuthenticatedUser;
@@ -26,5 +36,35 @@ export class BloodsController {
       request.user.userId,
       createBloodDto,
     );
+  }
+
+  @Get()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('facility')
+  findAll(@Req() request: AuthenticatedRequest) {
+    return this.bloodsService.findAllForFacility(request.user.userId);
+  }
+
+  @Get(':id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('facility')
+  findOne(
+    @Req() request: AuthenticatedRequest,
+    @Param() params: BloodIdParamDto,
+  ) {
+    return this.bloodsService.findOneForFacility(
+      request.user.userId,
+      params.id,
+    );
+  }
+
+  @Patch(':id/close')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('facility')
+  close(
+    @Req() request: AuthenticatedRequest,
+    @Param() params: BloodIdParamDto,
+  ) {
+    return this.bloodsService.closeForFacility(request.user.userId, params.id);
   }
 }

--- a/backend/src/bloods/bloods.service.ts
+++ b/backend/src/bloods/bloods.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   NotFoundException,
   UnauthorizedException,
+  ConflictException,
 } from '@nestjs/common';
 import { InjectModel } from '@mongoloquent/nestjs';
 import { ObjectId } from 'mongodb';
@@ -56,6 +57,124 @@ export class BloodsService {
         rhesus: blood.rhesus,
         quantity: blood.quantity,
         status_blood: blood.status_blood,
+        schedule: blood.schedule,
+        created_at: blood.created_at,
+      },
+    };
+  }
+
+  async findAllForFacility(userId: string) {
+    if (!ObjectId.isValid(userId)) {
+      throw new UnauthorizedException('Invalid authenticated user');
+    }
+
+    const hospital = await this.hospitalModel
+      .where('user_id', new ObjectId(userId))
+      .first();
+
+    if (!hospital) {
+      throw new NotFoundException(
+        'Hospital profile was not found for this facility',
+      );
+    }
+
+    const bloods = await this.bloodModel
+      .where('hospitals_id', hospital._id)
+      .get();
+
+    return {
+      success: true,
+      data: bloods.map((blood) => ({
+        id: blood._id.toString(),
+        hospitals_id: blood.hospitals_id.toString(),
+        blood_type: blood.blood_type,
+        rhesus: blood.rhesus,
+        quantity: blood.quantity,
+        status_blood: blood.status_blood,
+        schedule: blood.schedule,
+        created_at: blood.created_at,
+      })),
+    };
+  }
+
+  async findOneForFacility(userId: string, bloodId: string) {
+    if (!ObjectId.isValid(userId)) {
+      throw new UnauthorizedException('Invalid authenticated user');
+    }
+
+    const hospital = await this.hospitalModel
+      .where('user_id', new ObjectId(userId))
+      .first();
+
+    if (!hospital) {
+      throw new NotFoundException(
+        'Hospital profile was not found for this facility',
+      );
+    }
+
+    const blood = await this.bloodModel
+      .where('_id', new ObjectId(bloodId))
+      .first();
+
+    if (!blood || !blood.hospitals_id.equals(hospital._id)) {
+      throw new NotFoundException('Blood request was not found');
+    }
+
+    return {
+      success: true,
+      data: {
+        id: blood._id.toString(),
+        hospitals_id: blood.hospitals_id.toString(),
+        blood_type: blood.blood_type,
+        rhesus: blood.rhesus,
+        quantity: blood.quantity,
+        status_blood: blood.status_blood,
+        schedule: blood.schedule,
+        created_at: blood.created_at,
+      },
+    };
+  }
+
+  async closeForFacility(userId: string, bloodId: string) {
+    if (!ObjectId.isValid(userId)) {
+      throw new UnauthorizedException('Invalid authenticated user');
+    }
+
+    const hospital = await this.hospitalModel
+      .where('user_id', new ObjectId(userId))
+      .first();
+
+    if (!hospital) {
+      throw new NotFoundException(
+        'Hospital profile was not found for this facility',
+      );
+    }
+
+    const blood = await this.bloodModel
+      .where('_id', new ObjectId(bloodId))
+      .first();
+
+    if (!blood || !blood.hospitals_id.equals(hospital._id)) {
+      throw new NotFoundException('Blood request was not found');
+    }
+
+    if (blood.status_blood === 'closed') {
+      throw new ConflictException('Blood request is already closed');
+    }
+
+    await this.bloodModel.where('_id', blood._id).update({
+      status_blood: 'closed',
+    });
+
+    return {
+      success: true,
+      data: {
+        id: blood._id.toString(),
+        hospitals_id: blood.hospitals_id.toString(),
+        blood_type: blood.blood_type,
+        rhesus: blood.rhesus,
+        quantity: blood.quantity,
+        status_blood: 'closed',
         schedule: blood.schedule,
         created_at: blood.created_at,
       },

--- a/backend/src/bloods/dto/blood-id-param.dto.ts
+++ b/backend/src/bloods/dto/blood-id-param.dto.ts
@@ -1,0 +1,6 @@
+import { IsMongoId } from 'class-validator';
+
+export class BloodIdParamDto {
+  @IsMongoId()
+  id!: string;
+}


### PR DESCRIPTION
## Summary

- Add facility-owned blood request list endpoint
- Add facility-owned blood request detail endpoint
- Add endpoint to close a blood request
- Validate blood request ID as MongoDB ObjectId
- Enforce facility ownership for detail and close
- Reject repeated close operation with 409 Conflict

## Endpoints

- `GET /bloods`
- `GET /bloods/:id`
- `PATCH /bloods/:id/close`

## Verification

- `npm run build` ✅
- `npm test -- --runInBand` ✅
- Targeted ESLint check ✅
- Facility list → 200 ✅
- Facility detail → 200 ✅
- Close blood request → 200 ✅
- Close repeated → 409 ✅
- Invalid ID → 400 ✅
- Missing blood request → 404 ✅
- Facility ownership enforced → 404 ✅
- Without token → 401 ✅
- Donor token → 403 ✅

## Scope

Task B-02 only. No changes to shared models, authentication, dependencies, or environment configuration.