### PR TITLE
feat(B-03): add donor blood matching

### DIFF
--- a/backend/src/bloods/bloods.controller.ts
+++ b/backend/src/bloods/bloods.controller.ts
@@ -45,6 +45,13 @@ export class BloodsController {
     return this.bloodsService.findAllForFacility(request.user.userId);
   }
 
+  @Get('matches')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('donor')
+  findMatches(@Req() request: AuthenticatedRequest) {
+    return this.bloodsService.findMatchesForDonor(request.user.userId);
+  }
+
   @Get(':id')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('facility')

--- a/backend/src/bloods/bloods.module.ts
+++ b/backend/src/bloods/bloods.module.ts
@@ -5,9 +5,13 @@ import { Hospital } from '../hospitals/entities/hospital.model';
 import { BloodsController } from './bloods.controller';
 import { BloodsService } from './bloods.service';
 import { Blood } from './entities/blood.model';
+import { UserProfile } from '../profiles/entities/user-profile.model';
 
 @Module({
-  imports: [MongoloquentModule.forFeature([Blood, Hospital]), AuthModule],
+  imports: [
+    MongoloquentModule.forFeature([Blood, Hospital, UserProfile]),
+    AuthModule,
+  ],
   controllers: [BloodsController],
   providers: [BloodsService],
 })

--- a/backend/src/bloods/bloods.service.ts
+++ b/backend/src/bloods/bloods.service.ts
@@ -4,6 +4,8 @@ import {
   UnauthorizedException,
   ConflictException,
 } from '@nestjs/common';
+import { ELIGIBILITY_WINDOW_DAYS } from '../common/constants';
+import { UserProfile } from '../profiles/entities/user-profile.model';
 import { InjectModel } from '@mongoloquent/nestjs';
 import { ObjectId } from 'mongodb';
 import { Hospital } from '../hospitals/entities/hospital.model';
@@ -18,6 +20,9 @@ export class BloodsService {
 
     @InjectModel(Hospital)
     private readonly hospitalModel: Hospital,
+
+    @InjectModel(UserProfile)
+    private readonly userProfileModel: UserProfile,
   ) {}
 
   async createForFacility(userId: string, createBloodDto: CreateBloodDto) {
@@ -178,6 +183,54 @@ export class BloodsService {
         schedule: blood.schedule,
         created_at: blood.created_at,
       },
+    };
+  }
+
+  async findMatchesForDonor(userId: string) {
+    if (!ObjectId.isValid(userId)) {
+      throw new UnauthorizedException('Invalid authenticated user');
+    }
+
+    const profile = await this.userProfileModel
+      .where('user_id', new ObjectId(userId))
+      .first();
+
+    if (!profile) {
+      throw new NotFoundException('Donor profile was not found for this user');
+    }
+
+    if (profile.last_donor) {
+      const eligibleAt = new Date(profile.last_donor.getTime());
+
+      eligibleAt.setUTCDate(eligibleAt.getUTCDate() + ELIGIBILITY_WINDOW_DAYS);
+
+      if (eligibleAt > new Date()) {
+        return {
+          success: true,
+          data: [],
+        };
+      }
+    }
+
+    const matchingBloods = await this.bloodModel
+      .where('blood_type', profile.blood_type)
+      .where('rhesus', profile.rhesus)
+      .get();
+
+    return {
+      success: true,
+      data: matchingBloods
+        .filter((blood) => blood.status_blood !== 'closed')
+        .map((blood) => ({
+          id: blood._id.toString(),
+          hospitals_id: blood.hospitals_id.toString(),
+          blood_type: blood.blood_type,
+          rhesus: blood.rhesus,
+          quantity: blood.quantity,
+          status_blood: blood.status_blood,
+          schedule: blood.schedule,
+          created_at: blood.created_at,
+        })),
     };
   }
 }


### PR DESCRIPTION
## Summary

- Add donor-only blood matching endpoint
- Match needs by donor blood type and rhesus
- Exclude closed blood requests
- Enforce the canonical 90-day eligibility window
- Return no matches for currently ineligible donors
- Resolve donor profile from authenticated user

## Endpoint

- `GET /bloods/matches`

## Verification

- `npm run build` ✅
- `npm test -- --runInBand` ✅
- Targeted ESLint check ✅
- Matching blood type and rhesus → 200 ✅
- Different donors receive different matches ✅
- Closed requests excluded ✅
- `last_donor: null` eligible ✅
- Donation within 90 days returns empty matches ✅
- Donation older than 90 days returns matches ✅
- Donor without profile → 404 ✅
- Without token → 401 ✅
- Facility token → 403 ✅

## Scope

Task B-03 only. Radius filtering with `2dsphere`, `$near`, and
`$maxDistance` remains scoped to B-04.