### PR TITLE
feat(B-04): add radius-based blood matching

### DIFF
--- a/backend/src/bloods/bloods.controller.ts
+++ b/backend/src/bloods/bloods.controller.ts
@@ -7,6 +7,7 @@ import {
   Get,
   Param,
   Patch,
+  Query,
 } from '@nestjs/common';
 import type { Request } from 'express';
 import { Roles } from '../auth/decorators/roles.decorator';
@@ -16,6 +17,7 @@ import type { AuthenticatedUser } from '../auth/interfaces/jwt-payload.interface
 import { BloodsService } from './bloods.service';
 import { CreateBloodDto } from './dto/create-blood.dto';
 import { BloodIdParamDto } from './dto/blood-id-param.dto';
+import { MatchBloodsQueryDto } from './dto/match-bloods-query.dto';
 
 interface AuthenticatedRequest extends Request {
   user: AuthenticatedUser;
@@ -48,8 +50,14 @@ export class BloodsController {
   @Get('matches')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('donor')
-  findMatches(@Req() request: AuthenticatedRequest) {
-    return this.bloodsService.findMatchesForDonor(request.user.userId);
+  findMatches(
+    @Req() request: AuthenticatedRequest,
+    @Query() query: MatchBloodsQueryDto,
+  ) {
+    return this.bloodsService.findMatchesForDonor(
+      request.user.userId,
+      query.radius,
+    );
   }
 
   @Get(':id')

--- a/backend/src/bloods/bloods.service.ts
+++ b/backend/src/bloods/bloods.service.ts
@@ -3,6 +3,7 @@ import {
   NotFoundException,
   UnauthorizedException,
   ConflictException,
+  OnModuleInit,
 } from '@nestjs/common';
 import { ELIGIBILITY_WINDOW_DAYS } from '../common/constants';
 import { UserProfile } from '../profiles/entities/user-profile.model';
@@ -13,17 +14,27 @@ import { CreateBloodDto } from './dto/create-blood.dto';
 import { Blood } from './entities/blood.model';
 
 @Injectable()
-export class BloodsService {
+export class BloodsService implements OnModuleInit {
   constructor(
     @InjectModel(Blood)
     private readonly bloodModel: Blood,
 
     @InjectModel(Hospital)
-    private readonly hospitalModel: Hospital,
+    private readonly hospitalModel: typeof Hospital,
 
     @InjectModel(UserProfile)
     private readonly userProfileModel: UserProfile,
   ) {}
+
+  async onModuleInit() {
+    const hospitalCollection = this.hospitalModel
+      .query()
+      .getMongoDBCollection();
+
+    await hospitalCollection.createIndex({
+      location: '2dsphere',
+    });
+  }
 
   async createForFacility(userId: string, createBloodDto: CreateBloodDto) {
     if (!ObjectId.isValid(userId)) {
@@ -186,7 +197,7 @@ export class BloodsService {
     };
   }
 
-  async findMatchesForDonor(userId: string) {
+  async findMatchesForDonor(userId: string, radius: number) {
     if (!ObjectId.isValid(userId)) {
       throw new UnauthorizedException('Invalid authenticated user');
     }
@@ -212,16 +223,68 @@ export class BloodsService {
       }
     }
 
+    const hospitalCollection = this.hospitalModel
+      .query()
+      .getMongoDBCollection();
+
+    const nearbyHospitals = await hospitalCollection
+      .find({
+        location: {
+          $near: {
+            $geometry: profile.location,
+            $maxDistance: radius,
+          },
+        },
+      })
+      .toArray();
+
+    if (nearbyHospitals.length === 0) {
+      return {
+        success: true,
+        data: [],
+      };
+    }
+
+    const hospitalIds = nearbyHospitals.map((hospital) => hospital._id);
+
     const matchingBloods = await this.bloodModel
       .where('blood_type', profile.blood_type)
       .where('rhesus', profile.rhesus)
+      .whereIn('hospitals_id', hospitalIds)
       .get();
 
-    return {
-      success: true,
-      data: matchingBloods
-        .filter((blood) => blood.status_blood !== 'closed')
-        .map((blood) => ({
+    const hospitalsById = new Map(
+      nearbyHospitals.map(
+        (hospital, index) =>
+          [
+            hospital._id.toString(),
+            {
+              hospital,
+              order: index,
+            },
+          ] as const,
+      ),
+    );
+
+    const matches = Array.from(matchingBloods)
+      .filter((blood) => blood.status_blood !== 'closed')
+      .sort((firstBlood, secondBlood) => {
+        const firstOrder =
+          hospitalsById.get(firstBlood.hospitals_id.toString())?.order ??
+          Number.MAX_SAFE_INTEGER;
+
+        const secondOrder =
+          hospitalsById.get(secondBlood.hospitals_id.toString())?.order ??
+          Number.MAX_SAFE_INTEGER;
+
+        return firstOrder - secondOrder;
+      })
+      .map((blood) => {
+        const hospitalData = hospitalsById.get(
+          blood.hospitals_id.toString(),
+        )?.hospital;
+
+        return {
           id: blood._id.toString(),
           hospitals_id: blood.hospitals_id.toString(),
           blood_type: blood.blood_type,
@@ -230,7 +293,19 @@ export class BloodsService {
           status_blood: blood.status_blood,
           schedule: blood.schedule,
           created_at: blood.created_at,
-        })),
+          hospital: hospitalData
+            ? {
+                id: hospitalData._id.toString(),
+                hospital_name: hospitalData.hospital_name,
+                location: hospitalData.location,
+              }
+            : null,
+        };
+      });
+
+    return {
+      success: true,
+      data: matches,
     };
   }
 }

--- a/backend/src/bloods/dto/match-bloods-query.dto.ts
+++ b/backend/src/bloods/dto/match-bloods-query.dto.ts
@@ -1,0 +1,10 @@
+import { Type } from 'class-transformer';
+import { IsInt, Min, Max } from 'class-validator';
+
+export class MatchBloodsQueryDto {
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(50000)
+  radius!: number;
+}


### PR DESCRIPTION
## Summary

- Add radius query parameter to donor blood matching
- Validate radius between 1 and 50,000 meters
- Ensure a `2dsphere` index exists on hospital location
- Find nearby hospitals using `$near` and `$maxDistance`
- Filter matching blood requests by nearby hospital IDs
- Preserve blood type, rhesus, status, and eligibility matching
- Include hospital name and GeoJSON location in the response
- Order matches according to hospital proximity

## Endpoint

- `GET /bloods/matches?radius=10000`

## Verification

- `npm run build` ✅
- `npm test -- --runInBand` ✅
- Targeted ESLint check ✅
- Valid radius returns nearby matches → 200 ✅
- Nearby hospital included ✅
- Distant hospital excluded ✅
- Missing radius → 400 ✅
- Invalid/negative/zero radius → 400 ✅
- Radius over 50,000 meters → 400 ✅
- Blood type and rhesus matching preserved ✅
- Closed requests excluded ✅
- 90-day eligibility preserved ✅
- Without token → 401 ✅
- Facility token → 403 ✅
- `location_2dsphere` index verified in Atlas ✅

## Scope

Task B-04 only. Uses GeoJSON `[longitude, latitude]`,
`2dsphere`, `$near`, and `$maxDistance` in meters.