### PR TITLE
feat(B-05): add donor eligibility helper

### DIFF
--- a/backend/src/bloods/bloods.service.ts
+++ b/backend/src/bloods/bloods.service.ts
@@ -5,7 +5,7 @@ import {
   ConflictException,
   OnModuleInit,
 } from '@nestjs/common';
-import { ELIGIBILITY_WINDOW_DAYS } from '../common/constants';
+import { calculateDonorEligibility } from '../common/helpers/donor-eligibility.helper';
 import { UserProfile } from '../profiles/entities/user-profile.model';
 import { InjectModel } from '@mongoloquent/nestjs';
 import { ObjectId } from 'mongodb';
@@ -210,17 +210,13 @@ export class BloodsService implements OnModuleInit {
       throw new NotFoundException('Donor profile was not found for this user');
     }
 
-    if (profile.last_donor) {
-      const eligibleAt = new Date(profile.last_donor.getTime());
+    const eligibility = calculateDonorEligibility(profile.last_donor);
 
-      eligibleAt.setUTCDate(eligibleAt.getUTCDate() + ELIGIBILITY_WINDOW_DAYS);
-
-      if (eligibleAt > new Date()) {
-        return {
-          success: true,
-          data: [],
-        };
-      }
+    if (!eligibility.isEligible) {
+      return {
+        success: true,
+        data: [],
+      };
     }
 
     const hospitalCollection = this.hospitalModel

--- a/backend/src/common/helpers/donor-eligibility.helper.spec.ts
+++ b/backend/src/common/helpers/donor-eligibility.helper.spec.ts
@@ -1,0 +1,59 @@
+/// <reference types="jest" />
+
+import { calculateDonorEligibility } from './donor-eligibility.helper';
+
+describe('calculateDonorEligibility', () => {
+  it('marks a donor without donation history as eligible', () => {
+    const now = new Date('2026-08-15T00:00:00.000Z');
+
+    const result = calculateDonorEligibility(null, now);
+
+    expect(result).toEqual({
+      isEligible: true,
+      remainingDays: 0,
+      eligibleAt: null,
+    });
+  });
+
+  it('returns the remaining days before the eligibility date', () => {
+    const lastDonor = new Date('2026-01-01T00:00:00.000Z');
+    const now = new Date('2026-03-22T00:00:00.000Z');
+
+    const result = calculateDonorEligibility(lastDonor, now);
+
+    expect(result.isEligible).toBe(false);
+    expect(result.remainingDays).toBe(10);
+    expect(result.eligibleAt).toEqual(new Date('2026-04-01T00:00:00.000Z'));
+  });
+
+  it('rounds a partial remaining day upward', () => {
+    const lastDonor = new Date('2026-01-01T00:00:00.000Z');
+    const now = new Date('2026-03-31T12:00:00.000Z');
+
+    const result = calculateDonorEligibility(lastDonor, now);
+
+    expect(result.isEligible).toBe(false);
+    expect(result.remainingDays).toBe(1);
+  });
+
+  it('marks a donor as eligible exactly after 90 days', () => {
+    const lastDonor = new Date('2026-01-01T00:00:00.000Z');
+    const now = new Date('2026-04-01T00:00:00.000Z');
+
+    const result = calculateDonorEligibility(lastDonor, now);
+
+    expect(result.isEligible).toBe(true);
+    expect(result.remainingDays).toBe(0);
+    expect(result.eligibleAt).toEqual(new Date('2026-04-01T00:00:00.000Z'));
+  });
+
+  it('marks a donor as eligible after more than 90 days', () => {
+    const lastDonor = new Date('2026-01-01T00:00:00.000Z');
+    const now = new Date('2026-04-02T00:00:00.000Z');
+
+    const result = calculateDonorEligibility(lastDonor, now);
+
+    expect(result.isEligible).toBe(true);
+    expect(result.remainingDays).toBe(0);
+  });
+});

--- a/backend/src/common/helpers/donor-eligibility.helper.ts
+++ b/backend/src/common/helpers/donor-eligibility.helper.ts
@@ -1,0 +1,42 @@
+import { ELIGIBILITY_WINDOW_DAYS } from '../constants';
+
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export interface DonorEligibility {
+  isEligible: boolean;
+  remainingDays: number;
+  eligibleAt: Date | null;
+}
+
+export function calculateDonorEligibility(
+  lastDonor: Date | null,
+  now: Date = new Date(),
+): DonorEligibility {
+  if (!lastDonor) {
+    return {
+      isEligible: true,
+      remainingDays: 0,
+      eligibleAt: null,
+    };
+  }
+
+  const eligibleAt = new Date(lastDonor.getTime());
+
+  eligibleAt.setUTCDate(eligibleAt.getUTCDate() + ELIGIBILITY_WINDOW_DAYS);
+
+  const remainingMilliseconds = eligibleAt.getTime() - now.getTime();
+
+  if (remainingMilliseconds <= 0) {
+    return {
+      isEligible: true,
+      remainingDays: 0,
+      eligibleAt,
+    };
+  }
+
+  return {
+    isEligible: false,
+    remainingDays: Math.ceil(remainingMilliseconds / MILLISECONDS_PER_DAY),
+    eligibleAt,
+  };
+}


### PR DESCRIPTION
## Summary

- Add reusable donor eligibility helper
- Calculate eligibility from `last_donor`
- Use canonical 90-day eligibility window
- Return remaining days and next eligible date
- Handle donors without donation history
- Reuse helper in donor blood matching
- Remove duplicated eligibility calculation from blood service

## Verification

- `npm run build` ✅
- `npm test -- --runInBand` ✅
- Targeted ESLint check ✅
- No donation history → eligible ✅
- Donation within 90 days → ineligible with remaining days ✅
- Partial remaining day rounds upward ✅
- Exactly 90 days → eligible ✅
- More than 90 days → eligible ✅
- Existing B-03 matching behavior preserved ✅

## Scope

Task B-05 only. No changes to shared constants, models,
dependencies, environment configuration, or API contract.