### PR TITLE
feat(B-06): add donor profile endpoints

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,6 +6,7 @@ import { AppService } from './app.service';
 import { PocModule } from './poc/poc.module';
 import { AuthModule } from './auth/auth.module';
 import { BloodsModule } from './bloods/bloods.module';
+import { ProfilesModule } from './profiles/profiles.module';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { BloodsModule } from './bloods/bloods.module';
     PocModule,
     AuthModule,
     BloodsModule,
+    ProfilesModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/profiles/dto/geo-point.dto.ts
+++ b/backend/src/profiles/dto/geo-point.dto.ts
@@ -1,0 +1,18 @@
+import {
+  ArrayMaxSize,
+  ArrayMinSize,
+  Equals,
+  IsArray,
+  IsNumber,
+} from 'class-validator';
+
+export class GeoPointDto {
+  @Equals('Point')
+  type!: 'Point';
+
+  @IsArray()
+  @ArrayMinSize(2)
+  @ArrayMaxSize(2)
+  @IsNumber({}, { each: true })
+  coordinates!: [number, number];
+}

--- a/backend/src/profiles/dto/update-donor-profile.dto.ts
+++ b/backend/src/profiles/dto/update-donor-profile.dto.ts
@@ -1,0 +1,26 @@
+import { Type } from 'class-transformer';
+import {
+  IsDateString,
+  IsIn,
+  IsOptional,
+  ValidateNested,
+} from 'class-validator';
+import { BLOOD_TYPES, RHESUS_TYPES } from '../../common/constants';
+import type { BloodType, RhesusType } from '../../common/constants';
+import { GeoPointDto } from './geo-point.dto';
+
+export class UpdateDonorProfileDto {
+  @IsIn(BLOOD_TYPES)
+  blood_type!: BloodType;
+
+  @IsIn(RHESUS_TYPES)
+  rhesus!: RhesusType;
+
+  @ValidateNested()
+  @Type(() => GeoPointDto)
+  location!: GeoPointDto;
+
+  @IsOptional()
+  @IsDateString()
+  last_donor?: string | null;
+}

--- a/backend/src/profiles/profiles.controller.ts
+++ b/backend/src/profiles/profiles.controller.ts
@@ -1,0 +1,37 @@
+import { Body, Controller, Get, Patch, Req, UseGuards } from '@nestjs/common';
+import type { Request } from 'express';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import type { AuthenticatedUser } from '../auth/interfaces/jwt-payload.interface';
+import { UpdateDonorProfileDto } from './dto/update-donor-profile.dto';
+import { ProfilesService } from './profiles.service';
+
+interface AuthenticatedRequest extends Request {
+  user: AuthenticatedUser;
+}
+
+@Controller('profiles')
+export class ProfilesController {
+  constructor(private readonly profilesService: ProfilesService) {}
+
+  @Get('me')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('donor')
+  getMyProfile(@Req() request: AuthenticatedRequest) {
+    return this.profilesService.getForDonor(request.user.userId);
+  }
+
+  @Patch('me')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('donor')
+  updateMyProfile(
+    @Req() request: AuthenticatedRequest,
+    @Body() updateDonorProfileDto: UpdateDonorProfileDto,
+  ) {
+    return this.profilesService.updateForDonor(
+      request.user.userId,
+      updateDonorProfileDto,
+    );
+  }
+}

--- a/backend/src/profiles/profiles.module.ts
+++ b/backend/src/profiles/profiles.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { MongoloquentModule } from '@mongoloquent/nestjs';
+import { AuthModule } from '../auth/auth.module';
+import { UserProfile } from './entities/user-profile.model';
+import { ProfilesController } from './profiles.controller';
+import { ProfilesService } from './profiles.service';
+
+@Module({
+  imports: [MongoloquentModule.forFeature([UserProfile]), AuthModule],
+  controllers: [ProfilesController],
+  providers: [ProfilesService],
+})
+export class ProfilesModule {}

--- a/backend/src/profiles/profiles.service.ts
+++ b/backend/src/profiles/profiles.service.ts
@@ -1,0 +1,117 @@
+import {
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { InjectModel } from '@mongoloquent/nestjs';
+import { ObjectId } from 'mongodb';
+import { calculateDonorEligibility } from '../common/helpers/donor-eligibility.helper';
+import { UpdateDonorProfileDto } from './dto/update-donor-profile.dto';
+import { UserProfile } from './entities/user-profile.model';
+
+@Injectable()
+export class ProfilesService {
+  constructor(
+    @InjectModel(UserProfile)
+    private readonly userProfileModel: UserProfile,
+  ) {}
+
+  async getForDonor(userId: string) {
+    if (!ObjectId.isValid(userId)) {
+      throw new UnauthorizedException('Invalid authenticated user');
+    }
+
+    const profile = await this.userProfileModel
+      .where('user_id', new ObjectId(userId))
+      .first();
+
+    if (!profile) {
+      throw new NotFoundException('Donor profile was not found for this user');
+    }
+
+    const eligibility = calculateDonorEligibility(profile.last_donor);
+
+    return {
+      success: true,
+      data: {
+        id: profile._id.toString(),
+        user_id: profile.user_id.toString(),
+        blood_type: profile.blood_type,
+        rhesus: profile.rhesus,
+        location: profile.location,
+        last_donor: profile.last_donor,
+        eligibility: {
+          is_eligible: eligibility.isEligible,
+          remaining_days: eligibility.remainingDays,
+          eligible_at: eligibility.eligibleAt,
+        },
+      },
+    };
+  }
+
+  async updateForDonor(
+    userId: string,
+    updateDonorProfileDto: UpdateDonorProfileDto,
+  ) {
+    if (!ObjectId.isValid(userId)) {
+      throw new UnauthorizedException('Invalid authenticated user');
+    }
+
+    const userObjectId = new ObjectId(userId);
+
+    const existingProfile = await this.userProfileModel
+      .where('user_id', userObjectId)
+      .first();
+
+    const lastDonor = updateDonorProfileDto.last_donor
+      ? new Date(updateDonorProfileDto.last_donor)
+      : null;
+
+    const profileData = {
+      blood_type: updateDonorProfileDto.blood_type,
+      rhesus: updateDonorProfileDto.rhesus,
+      location: {
+        type: updateDonorProfileDto.location.type,
+        coordinates: updateDonorProfileDto.location.coordinates,
+      },
+      last_donor: lastDonor,
+    };
+
+    let profileId: string;
+
+    if (existingProfile) {
+      await this.userProfileModel
+        .where('_id', existingProfile._id)
+        .update(profileData);
+
+      profileId = existingProfile._id.toString();
+    } else {
+      const createdProfile = await this.userProfileModel.insert({
+        user_id: userObjectId,
+        ...profileData,
+        push_token: null,
+      });
+
+      profileId = createdProfile._id.toString();
+    }
+
+    const eligibility = calculateDonorEligibility(lastDonor);
+
+    return {
+      success: true,
+      data: {
+        id: profileId,
+        user_id: userId,
+        blood_type: profileData.blood_type,
+        rhesus: profileData.rhesus,
+        location: profileData.location,
+        last_donor: profileData.last_donor,
+        eligibility: {
+          is_eligible: eligibility.isEligible,
+          remaining_days: eligibility.remainingDays,
+          eligible_at: eligibility.eligibleAt,
+        },
+      },
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- Add donor profile get endpoint
- Add donor profile create/update endpoint
- Resolve profile ownership from authenticated JWT
- Validate blood type, rhesus, GeoJSON location, and last donor date
- Create profile when it does not exist
- Update the existing profile without creating duplicates
- Include donor eligibility status and remaining days
- Protect endpoints for donor role only

## Endpoints

- `GET /profiles/me`
- `PATCH /profiles/me`

## Verification

- `npm run build` ✅
- `npm test -- --runInBand` ✅
- Targeted ESLint check ✅
- GET before profile exists → 404 ✅
- First PATCH creates profile → 200 ✅
- Created profile returns a non-null ID ✅
- Subsequent PATCH updates the same profile ✅
- GET returns saved profile → 200 ✅
- Eligibility response verified ✅
- Invalid profile payload → 400 ✅
- Client-provided `user_id` or `push_token` → 400 ✅
- Without token → 401 ✅
- Facility token → 403 ✅
- Profile verified in MongoDB Atlas ✅

## Scope

Task B-06 only. No changes to shared models, authentication,
dependencies, constants, or environment configuration.