### PR TITLE
feat(B-07): add donor registration and screening

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -7,6 +7,7 @@ import { PocModule } from './poc/poc.module';
 import { AuthModule } from './auth/auth.module';
 import { BloodsModule } from './bloods/bloods.module';
 import { ProfilesModule } from './profiles/profiles.module';
+import { RequestsModule } from './requests/requests.module';
 
 @Module({
   imports: [
@@ -32,6 +33,7 @@ import { ProfilesModule } from './profiles/profiles.module';
     AuthModule,
     BloodsModule,
     ProfilesModule,
+    RequestsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/requests/dto/create-request.dto.ts
+++ b/backend/src/requests/dto/create-request.dto.ts
@@ -1,0 +1,28 @@
+import { Type } from 'class-transformer';
+import {
+  Equals,
+  IsBoolean,
+  IsMongoId,
+  IsObject,
+  ValidateNested,
+} from 'class-validator';
+
+export class RequestScreeningsDto {
+  @IsBoolean()
+  @Equals(true, {
+    message: 'Donor must pass the screening before registering',
+  })
+  screeningPassed!: true;
+
+  @IsObject()
+  screeningAnswers!: Record<string, unknown>;
+}
+
+export class CreateRequestDto {
+  @IsMongoId()
+  bloods_id!: string;
+
+  @ValidateNested()
+  @Type(() => RequestScreeningsDto)
+  screenings!: RequestScreeningsDto;
+}

--- a/backend/src/requests/dto/request-blood-param.dto.ts
+++ b/backend/src/requests/dto/request-blood-param.dto.ts
@@ -1,0 +1,6 @@
+import { IsMongoId } from 'class-validator';
+
+export class RequestBloodParamDto {
+  @IsMongoId()
+  bloodId!: string;
+}

--- a/backend/src/requests/requests.controller.ts
+++ b/backend/src/requests/requests.controller.ts
@@ -1,0 +1,52 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import type { Request } from 'express';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import type { AuthenticatedUser } from '../auth/interfaces/jwt-payload.interface';
+import { CreateRequestDto } from './dto/create-request.dto';
+import { RequestBloodParamDto } from './dto/request-blood-param.dto';
+import { RequestsService } from './requests.service';
+
+interface AuthenticatedRequest extends Request {
+  user: AuthenticatedUser;
+}
+
+@Controller('requests')
+export class RequestsController {
+  constructor(private readonly requestsService: RequestsService) {}
+
+  @Post()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('donor')
+  register(
+    @Req() request: AuthenticatedRequest,
+    @Body() createRequestDto: CreateRequestDto,
+  ) {
+    return this.requestsService.registerDonor(
+      request.user.userId,
+      createRequestDto,
+    );
+  }
+
+  @Get('blood/:bloodId')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('facility')
+  findApplicants(
+    @Req() request: AuthenticatedRequest,
+    @Param() params: RequestBloodParamDto,
+  ) {
+    return this.requestsService.findApplicantsForFacility(
+      request.user.userId,
+      params.bloodId,
+    );
+  }
+}

--- a/backend/src/requests/requests.module.ts
+++ b/backend/src/requests/requests.module.ts
@@ -1,0 +1,26 @@
+import { Module } from '@nestjs/common';
+import { MongoloquentModule } from '@mongoloquent/nestjs';
+import { AuthModule } from '../auth/auth.module';
+import { Blood } from '../bloods/entities/blood.model';
+import { Hospital } from '../hospitals/entities/hospital.model';
+import { UserProfile } from '../profiles/entities/user-profile.model';
+import { User } from '../users/entities/user.model';
+import { Request } from './entities/request.model';
+import { RequestsController } from './requests.controller';
+import { RequestsService } from './requests.service';
+
+@Module({
+  imports: [
+    MongoloquentModule.forFeature([
+      Request,
+      Blood,
+      UserProfile,
+      Hospital,
+      User,
+    ]),
+    AuthModule,
+  ],
+  controllers: [RequestsController],
+  providers: [RequestsService],
+})
+export class RequestsModule {}

--- a/backend/src/requests/requests.service.ts
+++ b/backend/src/requests/requests.service.ts
@@ -1,0 +1,173 @@
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { InjectModel } from '@mongoloquent/nestjs';
+import { randomUUID } from 'node:crypto';
+import { ObjectId } from 'mongodb';
+import { Blood } from '../bloods/entities/blood.model';
+import { calculateDonorEligibility } from '../common/helpers/donor-eligibility.helper';
+import { UserProfile } from '../profiles/entities/user-profile.model';
+import { CreateRequestDto } from './dto/create-request.dto';
+import { Request } from './entities/request.model';
+import { Hospital } from '../hospitals/entities/hospital.model';
+import { User } from '../users/entities/user.model';
+
+@Injectable()
+export class RequestsService {
+  constructor(
+    @InjectModel(Request)
+    private readonly requestModel: Request,
+
+    @InjectModel(Blood)
+    private readonly bloodModel: Blood,
+
+    @InjectModel(UserProfile)
+    private readonly userProfileModel: UserProfile,
+
+    @InjectModel(Hospital)
+    private readonly hospitalModel: Hospital,
+
+    @InjectModel(User)
+    private readonly userModel: User,
+  ) {}
+
+  async registerDonor(userId: string, createRequestDto: CreateRequestDto) {
+    if (!ObjectId.isValid(userId)) {
+      throw new UnauthorizedException('Invalid authenticated user');
+    }
+
+    const profile = await this.userProfileModel
+      .where('user_id', new ObjectId(userId))
+      .first();
+
+    if (!profile) {
+      throw new NotFoundException('Donor profile was not found for this user');
+    }
+
+    const eligibility = calculateDonorEligibility(profile.last_donor);
+
+    if (!eligibility.isEligible) {
+      throw new ConflictException(
+        `Donor is not eligible for another ${eligibility.remainingDays} day(s)`,
+      );
+    }
+
+    const blood = await this.bloodModel
+      .where('_id', new ObjectId(createRequestDto.bloods_id))
+      .first();
+
+    if (!blood) {
+      throw new NotFoundException('Blood request was not found');
+    }
+
+    if (blood.status_blood === 'closed') {
+      throw new ConflictException('Blood request is already closed');
+    }
+
+    if (
+      blood.blood_type !== profile.blood_type ||
+      blood.rhesus !== profile.rhesus
+    ) {
+      throw new ConflictException('Blood request does not match donor profile');
+    }
+
+    const existingRequest = await this.requestModel
+      .where('bloods_id', blood._id)
+      .where('user_Profiles_id', profile._id)
+      .first();
+
+    if (existingRequest) {
+      throw new ConflictException(
+        'Donor is already registered for this blood request',
+      );
+    }
+
+    const request = await this.requestModel.insert({
+      bloods_id: blood._id,
+      user_Profiles_id: profile._id,
+      screenings: {
+        screeningPassed: createRequestDto.screenings.screeningPassed,
+        screeningAnswers: createRequestDto.screenings.screeningAnswers,
+      },
+      status: 'registered',
+      qr_token: randomUUID(),
+    });
+
+    return {
+      success: true,
+      data: {
+        id: request._id.toString(),
+        bloods_id: request.bloods_id.toString(),
+        user_Profiles_id: request.user_Profiles_id.toString(),
+        screenings: request.screenings,
+        status: request.status,
+        qr_token: request.qr_token,
+      },
+    };
+  }
+
+  async findApplicantsForFacility(userId: string, bloodId: string) {
+    if (!ObjectId.isValid(userId)) {
+      throw new UnauthorizedException('Invalid authenticated user');
+    }
+
+    const hospital = await this.hospitalModel
+      .where('user_id', new ObjectId(userId))
+      .first();
+
+    if (!hospital) {
+      throw new NotFoundException(
+        'Hospital profile was not found for this facility',
+      );
+    }
+
+    const blood = await this.bloodModel
+      .where('_id', new ObjectId(bloodId))
+      .first();
+
+    if (!blood || !blood.hospitals_id.equals(hospital._id)) {
+      throw new NotFoundException('Blood request was not found');
+    }
+
+    const requests = await this.requestModel
+      .where('bloods_id', blood._id)
+      .get();
+
+    const applicants = await Promise.all(
+      Array.from(requests).map(async (request) => {
+        const profile = await this.userProfileModel
+          .where('_id', request.user_Profiles_id)
+          .first();
+
+        const user = profile
+          ? await this.userModel.where('_id', profile.user_id).first()
+          : null;
+
+        return {
+          id: request._id.toString(),
+          bloods_id: request.bloods_id.toString(),
+          user_Profiles_id: request.user_Profiles_id.toString(),
+          donor: profile
+            ? {
+                user_id: profile.user_id.toString(),
+                name: user?.name ?? null,
+                blood_type: profile.blood_type,
+                rhesus: profile.rhesus,
+              }
+            : null,
+          screenings: request.screenings,
+          status: request.status,
+          qr_token: request.qr_token,
+        };
+      }),
+    );
+
+    return {
+      success: true,
+      data: applicants,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- Add donor registration endpoint for blood requests
- Validate passed health screening
- Enforce donor eligibility window
- Enforce blood type and rhesus matching
- Reject closed blood requests
- Prevent duplicate donor registration
- Create requests with canonical `registered` status
- Generate a unique QR token using Node.js `randomUUID`
- Add facility-owned applicant list endpoint
- Include donor and screening information for facilities

## Endpoints

- `POST /requests`
- `GET /requests/blood/:bloodId`

## Verification

- `npm run build` ✅
- `npm test -- --runInBand` ✅
- Targeted ESLint check ✅
- Eligible matching donor registers → 201 ✅
- Facility sees registered donor → 200 ✅
- Initial status is `registered` ✅
- QR token generated and non-empty ✅
- Duplicate registration → 409 ✅
- Failed screening → 400 ✅
- Ineligible donor → 409 ✅
- Blood type/rhesus mismatch → 409 ✅
- Closed blood request → 409 ✅
- Facility ownership enforced → 404 ✅
- Invalid MongoDB ID → 400 ✅
- Without token → 401 ✅
- Incorrect role → 403 ✅
- Request verified in MongoDB Atlas ✅

## Coordination Note

B-07 generates `qr_token` during registration because the locked
request schema requires it. C-03 can reuse this token for QR check-in
and status transition.

## Scope

Task B-07 only. Status transition rules and QR check-in remain scoped
to C-01/C-03.