### PR TITLE
fix(B-04): limit matching radius to 20km

### DIFF
--- a/backend/src/bloods/dto/match-bloods-query.dto.ts
+++ b/backend/src/bloods/dto/match-bloods-query.dto.ts
@@ -5,6 +5,6 @@ export class MatchBloodsQueryDto {
   @Type(() => Number)
   @IsInt()
   @Min(1)
-  @Max(50000)
+  @Max(20000)
   radius!: number;
 }


### PR DESCRIPTION
## Summary

- Reduce maximum donor matching radius from 50 km to 20 km
- Keep radius units in meters
- Preserve existing `$near` and `$maxDistance` behavior

## Verification

- `npm run build` ✅
- `npm test -- --runInBand` ✅
- Targeted ESLint check ✅
- `radius=20000` → 200 ✅
- `radius=20001` → 400 ✅

## Scope

Validation-only revision for B-04. No changes to matching logic,
models, dependencies, or API response.