### PR TITLE
C-01 feat(status): add request status state machine

### DIFF
--- a/backend/src/requests/helpers/request-status.helper.spec.ts
+++ b/backend/src/requests/helpers/request-status.helper.spec.ts
@@ -1,0 +1,29 @@
+import { canTransitionRequestStatus } from './request-status.helper';
+
+describe('canTransitionRequestStatus', () => {
+  it('allows registered to transition to confirmed', () => {
+    expect(canTransitionRequestStatus('registered', 'confirmed')).toBe(true);
+  });
+
+  it('allows confirmed to transition to done', () => {
+    expect(canTransitionRequestStatus('confirmed', 'done')).toBe(true);
+  });
+
+  it('rejects registered to transition directly to done', () => {
+    expect(canTransitionRequestStatus('registered', 'done')).toBe(false);
+  });
+
+  it('rejects confirmed to transition back to registered', () => {
+    expect(canTransitionRequestStatus('confirmed', 'registered')).toBe(false);
+  });
+
+  it('rejects done to transition back to confirmed', () => {
+    expect(canTransitionRequestStatus('done', 'confirmed')).toBe(false);
+  });
+
+  it('rejects transition to the same status', () => {
+    expect(canTransitionRequestStatus('registered', 'registered')).toBe(false);
+    expect(canTransitionRequestStatus('confirmed', 'confirmed')).toBe(false);
+    expect(canTransitionRequestStatus('done', 'done')).toBe(false);
+  });
+});

--- a/backend/src/requests/helpers/request-status.helper.ts
+++ b/backend/src/requests/helpers/request-status.helper.ts
@@ -1,0 +1,17 @@
+import type { RequestStatus } from '../../common/constants';
+
+const REQUEST_STATUS_TRANSITIONS: Record<
+  RequestStatus,
+  readonly RequestStatus[]
+> = {
+  registered: ['confirmed'],
+  confirmed: ['done'],
+  done: [],
+};
+
+export function canTransitionRequestStatus(
+  currentStatus: RequestStatus,
+  nextStatus: RequestStatus,
+): boolean {
+  return REQUEST_STATUS_TRANSITIONS[currentStatus].includes(nextStatus);
+}


### PR DESCRIPTION
## Summary

- Add request status transition helper
- Allow `registered → confirmed`
- Allow `confirmed → done`
- Reject skipped, backward, and repeated transitions

## Testing

- `npm test -- request-status.helper.spec.ts`
- `npm run build`