### PR TITLE
C-02 Add facility request approval endpoint

### DIFF
--- a/backend/src/requests/dto/request-id-param.dto.ts
+++ b/backend/src/requests/dto/request-id-param.dto.ts
@@ -1,0 +1,6 @@
+import { IsMongoId } from 'class-validator';
+
+export class RequestIdParamDto {
+  @IsMongoId()
+  id!: string;
+}

--- a/backend/src/requests/requests.controller.ts
+++ b/backend/src/requests/requests.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Get,
   Param,
+  Patch,
   Post,
   Req,
   UseGuards,
@@ -14,6 +15,7 @@ import { RolesGuard } from '../auth/guards/roles.guard';
 import type { AuthenticatedUser } from '../auth/interfaces/jwt-payload.interface';
 import { CreateRequestDto } from './dto/create-request.dto';
 import { RequestBloodParamDto } from './dto/request-blood-param.dto';
+import { RequestIdParamDto } from './dto/request-id-param.dto';
 import { RequestsService } from './requests.service';
 
 interface AuthenticatedRequest extends Request {
@@ -47,6 +49,19 @@ export class RequestsController {
     return this.requestsService.findApplicantsForFacility(
       request.user.userId,
       params.bloodId,
+    );
+  }
+
+  @Patch(':id/confirm')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('facility')
+  confirm(
+    @Req() request: AuthenticatedRequest,
+    @Param() params: RequestIdParamDto,
+  ) {
+    return this.requestsService.confirmForFacility(
+      request.user.userId,
+      params.id,
     );
   }
 }

--- a/backend/src/requests/requests.service.ts
+++ b/backend/src/requests/requests.service.ts
@@ -1,19 +1,20 @@
+import { InjectModel } from '@mongoloquent/nestjs';
 import {
   ConflictException,
   Injectable,
   NotFoundException,
   UnauthorizedException,
 } from '@nestjs/common';
-import { InjectModel } from '@mongoloquent/nestjs';
-import { randomUUID } from 'node:crypto';
 import { ObjectId } from 'mongodb';
+import { randomUUID } from 'node:crypto';
 import { Blood } from '../bloods/entities/blood.model';
 import { calculateDonorEligibility } from '../common/helpers/donor-eligibility.helper';
+import { Hospital } from '../hospitals/entities/hospital.model';
 import { UserProfile } from '../profiles/entities/user-profile.model';
+import { User } from '../users/entities/user.model';
 import { CreateRequestDto } from './dto/create-request.dto';
 import { Request } from './entities/request.model';
-import { Hospital } from '../hospitals/entities/hospital.model';
-import { User } from '../users/entities/user.model';
+import { canTransitionRequestStatus } from './helpers/request-status.helper';
 
 @Injectable()
 export class RequestsService {
@@ -168,6 +169,60 @@ export class RequestsService {
     return {
       success: true,
       data: applicants,
+    };
+  }
+
+  async confirmForFacility(userId: string, requestId: string) {
+    if (!ObjectId.isValid(userId)) {
+      throw new UnauthorizedException('Invalid authenticated user');
+    }
+
+    const hospital = await this.hospitalModel
+      .where('user_id', new ObjectId(userId))
+      .first();
+
+    if (!hospital) {
+      throw new NotFoundException(
+        'Hospital profile was not found for this facility',
+      );
+    }
+
+    const donorRequest = await this.requestModel
+      .where('_id', new ObjectId(requestId))
+      .first();
+
+    if (!donorRequest) {
+      throw new NotFoundException('Donor request was not found');
+    }
+
+    const blood = await this.bloodModel
+      .where('_id', donorRequest.bloods_id)
+      .first();
+
+    if (!blood || !blood.hospitals_id.equals(hospital._id)) {
+      throw new NotFoundException('Donor request was not found');
+    }
+
+    if (!canTransitionRequestStatus(donorRequest.status, 'confirmed')) {
+      throw new ConflictException(
+        `Request status cannot transition from ${donorRequest.status} to confirmed`,
+      );
+    }
+
+    await this.requestModel.where('_id', donorRequest._id).update({
+      status: 'confirmed',
+    });
+
+    return {
+      success: true,
+      data: {
+        id: donorRequest._id.toString(),
+        bloods_id: donorRequest.bloods_id.toString(),
+        user_Profiles_id: donorRequest.user_Profiles_id.toString(),
+        screenings: donorRequest.screenings,
+        status: 'confirmed',
+        qr_token: donorRequest.qr_token,
+      },
     };
   }
 }


### PR DESCRIPTION
## Summary

- Add request ID parameter validation
- Add facility-only request approval endpoint
- Validate ownership of the blood request
- Apply `registered → confirmed` state transition
- Reject invalid and repeated transitions

## Endpoint

`PATCH /requests/:id/confirm`

## Testing

- `npm run build`
- `npm test` — 12 tests passed
- Valid transition returns `200 OK`
- Repeated confirmation returns `409 Conflict`