### PR TITLE
feat(qr): add facility QR check-in endpoint

### DIFF
--- a/backend/src/requests/dto/check-in-request.dto.ts
+++ b/backend/src/requests/dto/check-in-request.dto.ts
@@ -1,0 +1,6 @@
+import { IsUUID } from 'class-validator';
+
+export class CheckInRequestDto {
+  @IsUUID()
+  qr_token!: string;
+}

--- a/backend/src/requests/requests.controller.ts
+++ b/backend/src/requests/requests.controller.ts
@@ -16,6 +16,7 @@ import type { AuthenticatedUser } from '../auth/interfaces/jwt-payload.interface
 import { CreateRequestDto } from './dto/create-request.dto';
 import { RequestBloodParamDto } from './dto/request-blood-param.dto';
 import { RequestIdParamDto } from './dto/request-id-param.dto';
+import { CheckInRequestDto } from './dto/check-in-request.dto';
 import { RequestsService } from './requests.service';
 
 interface AuthenticatedRequest extends Request {
@@ -62,6 +63,19 @@ export class RequestsController {
     return this.requestsService.confirmForFacility(
       request.user.userId,
       params.id,
+    );
+  }
+
+  @Patch('check-in')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('facility')
+  checkIn(
+    @Req() request: AuthenticatedRequest,
+    @Body() checkInRequestDto: CheckInRequestDto,
+  ) {
+    return this.requestsService.checkInForFacility(
+      request.user.userId,
+      checkInRequestDto.qr_token,
     );
   }
 }

--- a/backend/src/requests/requests.service.ts
+++ b/backend/src/requests/requests.service.ts
@@ -225,4 +225,58 @@ export class RequestsService {
       },
     };
   }
+
+  async checkInForFacility(userId: string, qrToken: string) {
+    if (!ObjectId.isValid(userId)) {
+      throw new UnauthorizedException('Invalid authenticated user');
+    }
+
+    const hospital = await this.hospitalModel
+      .where('user_id', new ObjectId(userId))
+      .first();
+
+    if (!hospital) {
+      throw new NotFoundException(
+        'Hospital profile was not found for this facility',
+      );
+    }
+
+    const donorRequest = await this.requestModel
+      .where('qr_token', qrToken)
+      .first();
+
+    if (!donorRequest) {
+      throw new NotFoundException('Donor request was not found');
+    }
+
+    const blood = await this.bloodModel
+      .where('_id', donorRequest.bloods_id)
+      .first();
+
+    if (!blood || !blood.hospitals_id.equals(hospital._id)) {
+      throw new NotFoundException('Donor request was not found');
+    }
+
+    if (!canTransitionRequestStatus(donorRequest.status, 'done')) {
+      throw new ConflictException(
+        `Request status cannot transition from ${donorRequest.status} to done`,
+      );
+    }
+
+    await this.requestModel.where('_id', donorRequest._id).update({
+      status: 'done',
+    });
+
+    return {
+      success: true,
+      data: {
+        id: donorRequest._id.toString(),
+        bloods_id: donorRequest.bloods_id.toString(),
+        user_Profiles_id: donorRequest.user_Profiles_id.toString(),
+        screenings: donorRequest.screenings,
+        status: 'done',
+        qr_token: donorRequest.qr_token,
+      },
+    };
+  }
 }


### PR DESCRIPTION
## Summary

- Add QR token request validation
- Add facility-only QR check-in endpoint
- Validate ownership of the donor request
- Apply `confirmed → done` state transition
- Reject invalid and repeated check-ins

## Endpoint

`PATCH /requests/check-in`

## Testing

- `npm run build`
- `npm test` — 12 tests passed
- Valid check-in returns `200 OK`
- Repeated check-in returns `409 Conflict`