### PR TITLE
feat(C-04): add urgent donor push notifications

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -20,6 +20,7 @@
         "bcrypt": "^6.0.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.15.1",
+        "expo-server-sdk": "^7.1.0",
         "mongodb": "^6.21.0",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
@@ -5221,6 +5222,12 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "license": "MIT"
+    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -5604,6 +5611,20 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/expo-server-sdk": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/expo-server-sdk/-/expo-server-sdk-7.1.0.tgz",
+      "integrity": "sha512-75n+Tsa7uSIKtSVpKUX/h2hPL8eDG/omG+GIoTwbxUeC3aFOWXU7TcJd9lAjZcDAFnOR+scwCc5G1UbhXF9adg==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-limit": "^2.7.0",
+        "promise-retry": "^2.0.1",
+        "undici": "^7.2.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/express": {
@@ -8796,6 +8817,25 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/promise-limit": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/promise-limit/-/promise-limit-2.7.0.tgz",
+      "integrity": "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==",
+      "license": "ISC"
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -9002,6 +9042,15 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/router": {
       "version": "2.2.0",
@@ -10195,6 +10244,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -33,6 +33,7 @@
     "bcrypt": "^6.0.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",
+    "expo-server-sdk": "^7.1.0",
     "mongodb": "^6.21.0",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -8,6 +8,7 @@ import { AuthModule } from './auth/auth.module';
 import { BloodsModule } from './bloods/bloods.module';
 import { ProfilesModule } from './profiles/profiles.module';
 import { RequestsModule } from './requests/requests.module';
+import { NotificationsModule } from './notifications/notifications.module';
 
 @Module({
   imports: [
@@ -34,6 +35,7 @@ import { RequestsModule } from './requests/requests.module';
     BloodsModule,
     ProfilesModule,
     RequestsModule,
+    NotificationsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/bloods/bloods.module.ts
+++ b/backend/src/bloods/bloods.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { MongoloquentModule } from '@mongoloquent/nestjs';
 import { AuthModule } from '../auth/auth.module';
 import { Hospital } from '../hospitals/entities/hospital.model';
+import { NotificationsModule } from '../notifications/notifications.module';
 import { BloodsController } from './bloods.controller';
 import { BloodsService } from './bloods.service';
 import { Blood } from './entities/blood.model';
@@ -11,6 +12,7 @@ import { UserProfile } from '../profiles/entities/user-profile.model';
   imports: [
     MongoloquentModule.forFeature([Blood, Hospital, UserProfile]),
     AuthModule,
+    NotificationsModule,
   ],
   controllers: [BloodsController],
   providers: [BloodsService],

--- a/backend/src/bloods/bloods.service.ts
+++ b/backend/src/bloods/bloods.service.ts
@@ -1,20 +1,24 @@
-import {
-  Injectable,
-  NotFoundException,
-  UnauthorizedException,
-  ConflictException,
-  OnModuleInit,
-} from '@nestjs/common';
-import { calculateDonorEligibility } from '../common/helpers/donor-eligibility.helper';
-import { UserProfile } from '../profiles/entities/user-profile.model';
 import { InjectModel } from '@mongoloquent/nestjs';
+import {
+  ConflictException,
+  Injectable,
+  Logger,
+  NotFoundException,
+  OnModuleInit,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { ObjectId } from 'mongodb';
+import { calculateDonorEligibility } from '../common/helpers/donor-eligibility.helper';
 import { Hospital } from '../hospitals/entities/hospital.model';
+import { NotificationsService } from '../notifications/notifications.service';
+import { UserProfile } from '../profiles/entities/user-profile.model';
 import { CreateBloodDto } from './dto/create-blood.dto';
 import { Blood } from './entities/blood.model';
 
 @Injectable()
 export class BloodsService implements OnModuleInit {
+  private readonly logger = new Logger(BloodsService.name);
+
   constructor(
     @InjectModel(Blood)
     private readonly bloodModel: Blood,
@@ -24,6 +28,8 @@ export class BloodsService implements OnModuleInit {
 
     @InjectModel(UserProfile)
     private readonly userProfileModel: UserProfile,
+
+    private readonly notificationsService: NotificationsService,
   ) {}
 
   async onModuleInit() {
@@ -42,7 +48,7 @@ export class BloodsService implements OnModuleInit {
     }
 
     const hospital = await this.hospitalModel
-      .where(`user_id`, new ObjectId(userId))
+      .where('user_id', new ObjectId(userId))
       .first();
 
     if (!hospital) {
@@ -63,6 +69,32 @@ export class BloodsService implements OnModuleInit {
       schedule,
       created_at: createdAt,
     });
+
+    if (blood.status_blood === 'urgent') {
+      try {
+        const pushResult =
+          await this.notificationsService.sendUrgentBloodNotification({
+            bloodId: blood._id.toString(),
+            bloodType: blood.blood_type,
+            rhesus: blood.rhesus,
+            hospitalName: hospital.hospital_name,
+            hospitalLocation: hospital.location,
+          });
+
+        this.logger.log(
+          `Urgent notification processed for ${pushResult.matched_donors} donor(s)`,
+        );
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error
+            ? error.message
+            : 'Unknown push notification error';
+
+        this.logger.error(
+          `Failed to send urgent blood notification: ${errorMessage}`,
+        );
+      }
+    }
 
     return {
       success: true,

--- a/backend/src/common/constants.ts
+++ b/backend/src/common/constants.ts
@@ -19,3 +19,5 @@ export const REQUEST_STATUSES = ['registered', 'confirmed', 'done'] as const;
 export type RequestStatus = (typeof REQUEST_STATUSES)[number];
 
 export const ELIGIBILITY_WINDOW_DAYS = 90;
+
+export const URGENT_PUSH_RADIUS_METERS = 20000;

--- a/backend/src/notifications/dto/update-push-token.dto.ts
+++ b/backend/src/notifications/dto/update-push-token.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class UpdatePushTokenDto {
+  @IsString()
+  @IsNotEmpty()
+  push_token!: string;
+}

--- a/backend/src/notifications/notifications.controller.ts
+++ b/backend/src/notifications/notifications.controller.ts
@@ -1,0 +1,30 @@
+import { Body, Controller, Patch, Req, UseGuards } from '@nestjs/common';
+import type { Request } from 'express';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import type { AuthenticatedUser } from '../auth/interfaces/jwt-payload.interface';
+import { UpdatePushTokenDto } from './dto/update-push-token.dto';
+import { NotificationsService } from './notifications.service';
+
+interface AuthenticatedRequest extends Request {
+  user: AuthenticatedUser;
+}
+
+@Controller('notifications')
+export class NotificationsController {
+  constructor(private readonly notificationsService: NotificationsService) {}
+
+  @Patch('push-token')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('donor')
+  updatePushToken(
+    @Req() request: AuthenticatedRequest,
+    @Body() updatePushTokenDto: UpdatePushTokenDto,
+  ) {
+    return this.notificationsService.updatePushTokenForDonor(
+      request.user.userId,
+      updatePushTokenDto.push_token,
+    );
+  }
+}

--- a/backend/src/notifications/notifications.module.ts
+++ b/backend/src/notifications/notifications.module.ts
@@ -1,0 +1,14 @@
+import { MongoloquentModule } from '@mongoloquent/nestjs';
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
+import { UserProfile } from '../profiles/entities/user-profile.model';
+import { NotificationsController } from './notifications.controller';
+import { NotificationsService } from './notifications.service';
+
+@Module({
+  imports: [MongoloquentModule.forFeature([UserProfile]), AuthModule],
+  controllers: [NotificationsController],
+  providers: [NotificationsService],
+  exports: [NotificationsService],
+})
+export class NotificationsModule {}

--- a/backend/src/notifications/notifications.service.ts
+++ b/backend/src/notifications/notifications.service.ts
@@ -1,0 +1,141 @@
+import { InjectModel } from '@mongoloquent/nestjs';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+  OnModuleInit,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Expo } from 'expo-server-sdk';
+import type { ExpoPushMessage, ExpoPushTicket } from 'expo-server-sdk';
+import { ObjectId } from 'mongodb';
+import type { BloodType, RhesusType } from '../common/constants';
+import { URGENT_PUSH_RADIUS_METERS } from '../common/constants';
+import { calculateDonorEligibility } from '../common/helpers/donor-eligibility.helper';
+import type { GeoPoint } from '../common/interfaces/geo-point.interface';
+import { UserProfile } from '../profiles/entities/user-profile.model';
+
+interface UrgentBloodNotification {
+  bloodId: string;
+  bloodType: BloodType;
+  rhesus: RhesusType;
+  hospitalName: string;
+  hospitalLocation: GeoPoint;
+}
+
+@Injectable()
+export class NotificationsService implements OnModuleInit {
+  private readonly expo = new Expo();
+
+  constructor(
+    @InjectModel(UserProfile)
+    private readonly userProfileModel: typeof UserProfile,
+  ) {}
+
+  async onModuleInit() {
+    const userProfileCollection = this.userProfileModel
+      .query()
+      .getMongoDBCollection();
+
+    await userProfileCollection.createIndex({
+      location: '2dsphere',
+    });
+  }
+
+  async updatePushTokenForDonor(userId: string, pushToken: string) {
+    if (!ObjectId.isValid(userId)) {
+      throw new UnauthorizedException('Invalid authenticated user');
+    }
+
+    if (!Expo.isExpoPushToken(pushToken)) {
+      throw new BadRequestException('Invalid Expo push token');
+    }
+
+    const profile = await this.userProfileModel
+      .where('user_id', new ObjectId(userId))
+      .first();
+
+    if (!profile) {
+      throw new NotFoundException('Donor profile was not found for this user');
+    }
+
+    await this.userProfileModel.where('_id', profile._id).update({
+      push_token: pushToken,
+    });
+
+    return {
+      success: true,
+      data: {
+        user_Profiles_id: profile._id.toString(),
+        push_token: pushToken,
+      },
+    };
+  }
+
+  async sendUrgentBloodNotification(notification: UrgentBloodNotification) {
+    const userProfileCollection = this.userProfileModel
+      .query()
+      .getMongoDBCollection();
+
+    const nearbyProfiles = await userProfileCollection
+      .find({
+        blood_type: notification.bloodType,
+        rhesus: notification.rhesus,
+        push_token: {
+          $type: 'string',
+          $ne: '',
+        },
+        location: {
+          $near: {
+            $geometry: notification.hospitalLocation,
+            $maxDistance: URGENT_PUSH_RADIUS_METERS,
+          },
+        },
+      })
+      .toArray();
+
+    const messages = nearbyProfiles.flatMap((profile): ExpoPushMessage[] => {
+      const eligibility = calculateDonorEligibility(profile.last_donor ?? null);
+
+      const pushToken = profile.push_token;
+
+      if (!eligibility.isEligible || !Expo.isExpoPushToken(pushToken)) {
+        return [];
+      }
+
+      return [
+        {
+          to: pushToken,
+          sound: 'default',
+          title: 'Kebutuhan Darah Mendesak',
+          body: `${notification.hospitalName} membutuhkan donor ${notification.bloodType}${notification.rhesus}`,
+          data: {
+            bloods_id: notification.bloodId,
+            type: 'urgent_blood_request',
+          },
+        },
+      ];
+    });
+
+    if (messages.length === 0) {
+      return {
+        matched_donors: 0,
+        tickets: [],
+      };
+    }
+
+    const chunks = this.expo.chunkPushNotifications(messages);
+    const tickets: ExpoPushTicket[] = [];
+
+    for (const chunk of chunks) {
+      const ticketChunk = await this.expo.sendPushNotificationsAsync(chunk);
+
+      tickets.push(...ticketChunk);
+    }
+
+    return {
+      matched_donors: messages.length,
+      tickets,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- Add donor Expo push-token endpoint
- Validate Expo push-token format
- Store `push_token` in donor profile
- Match eligible donors by blood type, rhesus, and 20 km radius
- Trigger push when a facility creates an urgent blood request
- Keep blood creation successful when the Expo service fails

## Endpoints

- `PATCH /notifications/push-token`
- Existing `POST /bloods` now triggers push for `status_blood="urgent"`

## Testing

- `npm run build`
- `npm test`
- Valid token is stored successfully
- Invalid token returns `400 Bad Request`
- Urgent blood creation returns `201 Created`
- Matching log: `Urgent notification processed for 1 donor(s)`

## Note

Physical-device delivery will be verified during frontend task D-15 using a real Expo Push Token.