### PR TITLE
fix(B-E1): add donor requests endpoint

### DIFF
--- a/backend/src/requests/dto/my-requests-query.dto.ts
+++ b/backend/src/requests/dto/my-requests-query.dto.ts
@@ -1,0 +1,8 @@
+import { IsIn, IsOptional } from 'class-validator';
+import { REQUEST_STATUSES, type RequestStatus } from '../../common/constants';
+
+export class MyRequestsQueryDto {
+  @IsOptional()
+  @IsIn(REQUEST_STATUSES)
+  status?: RequestStatus;
+}

--- a/backend/src/requests/requests.controller.ts
+++ b/backend/src/requests/requests.controller.ts
@@ -7,6 +7,7 @@ import {
   Post,
   Req,
   UseGuards,
+  Query,
 } from '@nestjs/common';
 import type { Request } from 'express';
 import { Roles } from '../auth/decorators/roles.decorator';
@@ -18,6 +19,7 @@ import { RequestBloodParamDto } from './dto/request-blood-param.dto';
 import { RequestIdParamDto } from './dto/request-id-param.dto';
 import { CheckInRequestDto } from './dto/check-in-request.dto';
 import { RequestsService } from './requests.service';
+import { MyRequestsQueryDto } from './dto/my-requests-query.dto';
 
 interface AuthenticatedRequest extends Request {
   user: AuthenticatedUser;
@@ -37,6 +39,19 @@ export class RequestsController {
     return this.requestsService.registerDonor(
       request.user.userId,
       createRequestDto,
+    );
+  }
+
+  @Get('me')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('donor')
+  findMine(
+    @Req() request: AuthenticatedRequest,
+    @Query() query: MyRequestsQueryDto,
+  ) {
+    return this.requestsService.findMineForDonor(
+      request.user.userId,
+      query.status,
     );
   }
 

--- a/backend/src/requests/requests.service.ts
+++ b/backend/src/requests/requests.service.ts
@@ -15,6 +15,7 @@ import { User } from '../users/entities/user.model';
 import { CreateRequestDto } from './dto/create-request.dto';
 import { Request } from './entities/request.model';
 import { canTransitionRequestStatus } from './helpers/request-status.helper';
+import type { RequestStatus } from '../common/constants';
 
 @Injectable()
 export class RequestsService {
@@ -277,6 +278,73 @@ export class RequestsService {
         status: 'done',
         qr_token: donorRequest.qr_token,
       },
+    };
+  }
+
+  async findMineForDonor(userId: string, status?: RequestStatus) {
+    if (!ObjectId.isValid(userId)) {
+      throw new UnauthorizedException('Invalid authenticated user');
+    }
+
+    const profile = await this.userProfileModel
+      .where('user_id', new ObjectId(userId))
+      .first();
+
+    if (!profile) {
+      return {
+        success: true,
+        data: [],
+      };
+    }
+
+    const donorRequests = status
+      ? await this.requestModel
+          .where('user_Profiles_id', profile._id)
+          .where('status', status)
+          .get()
+      : await this.requestModel.where('user_Profiles_id', profile._id).get();
+
+    const data = await Promise.all(
+      Array.from(donorRequests).map(async (donorRequest) => {
+        const blood = await this.bloodModel
+          .where('_id', donorRequest.bloods_id)
+          .first();
+
+        const hospital = blood
+          ? await this.hospitalModel.where('_id', blood.hospitals_id).first()
+          : null;
+
+        return {
+          id: donorRequest._id.toString(),
+          code: null,
+          qr_token: donorRequest.qr_token,
+          status: donorRequest.status,
+          checked_in_at: null,
+          blood: blood
+            ? {
+                id: blood._id.toString(),
+                blood_type: blood.blood_type,
+                rhesus: blood.rhesus,
+                quantity: blood.quantity,
+                status_blood: blood.status_blood,
+                schedule: blood.schedule,
+                title: null,
+              }
+            : null,
+          hospital: hospital
+            ? {
+                hospital_name: hospital.hospital_name,
+                address: null,
+                location: hospital.location,
+              }
+            : null,
+        };
+      }),
+    );
+
+    return {
+      success: true,
+      data,
     };
   }
 }


### PR DESCRIPTION
## Summary

- Add `GET /requests/me` for authenticated donors
- Support optional status filtering
- Include related blood and hospital data
- Return an empty array when donor profile is unavailable
- Preserve existing request endpoints and response envelope
- Add null placeholders for fields delivered by later additive tasks

## Endpoint

- `GET /requests/me`
- `GET /requests/me?status=registered|confirmed|done`

## Verification

- `npm run build` ✅
- `npm test -- --runInBand` ✅
- Targeted ESLint check ✅
- Donor requests → 200 ✅
- Status filters → 200 ✅
- Invalid status → 400 ✅
- Donor without profile → empty array ✅
- Without token → 401 ✅
- Facility token → 403 ✅

## Scope

B-E1 only. No existing endpoint, model, enum, or response field
was removed or renamed.