### PR TITLE
fix(B-A1): add donor profile fields

### DIFF
--- a/backend/src/profiles/dto/update-donor-profile.dto.ts
+++ b/backend/src/profiles/dto/update-donor-profile.dto.ts
@@ -2,7 +2,11 @@ import { Type } from 'class-transformer';
 import {
   IsDateString,
   IsIn,
+  IsNumber,
   IsOptional,
+  IsString,
+  Max,
+  Min,
   ValidateNested,
 } from 'class-validator';
 import { BLOOD_TYPES, RHESUS_TYPES } from '../../common/constants';
@@ -23,4 +27,23 @@ export class UpdateDonorProfileDto {
   @IsOptional()
   @IsDateString()
   last_donor?: string | null;
+
+  @IsOptional()
+  @IsDateString()
+  birth_date?: string | null;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  weight_kg?: number | null;
+
+  @IsOptional()
+  @IsString()
+  city?: string | null;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  @Max(20)
+  notify_radius_km?: number | null;
 }

--- a/backend/src/profiles/entities/user-profile.model.ts
+++ b/backend/src/profiles/entities/user-profile.model.ts
@@ -12,6 +12,11 @@ export interface IUserProfile extends IMongoloquentSchema {
   location: GeoPoint;
   last_donor: Date | null;
   push_token: string | null;
+
+  birth_date?: Date | null;
+  weight_kg?: number | null;
+  city?: string | null;
+  notify_radius_km?: number | null;
 }
 
 export class UserProfile extends Model<IUserProfile> {

--- a/backend/src/profiles/profiles.service.ts
+++ b/backend/src/profiles/profiles.service.ts
@@ -40,6 +40,10 @@ export class ProfilesService {
         rhesus: profile.rhesus,
         location: profile.location,
         last_donor: profile.last_donor,
+        birth_date: profile.birth_date ?? null,
+        weight_kg: profile.weight_kg ?? null,
+        city: profile.city ?? null,
+        notify_radius_km: profile.notify_radius_km ?? null,
         eligibility: {
           is_eligible: eligibility.isEligible,
           remaining_days: eligibility.remainingDays,
@@ -67,6 +71,13 @@ export class ProfilesService {
       ? new Date(updateDonorProfileDto.last_donor)
       : null;
 
+    const birthDate =
+      updateDonorProfileDto.birth_date === undefined
+        ? undefined
+        : updateDonorProfileDto.birth_date
+          ? new Date(updateDonorProfileDto.birth_date)
+          : null;
+
     const profileData = {
       blood_type: updateDonorProfileDto.blood_type,
       rhesus: updateDonorProfileDto.rhesus,
@@ -75,6 +86,18 @@ export class ProfilesService {
         coordinates: updateDonorProfileDto.location.coordinates,
       },
       last_donor: lastDonor,
+      ...(birthDate !== undefined ? { birth_date: birthDate } : {}),
+      ...(updateDonorProfileDto.weight_kg !== undefined
+        ? { weight_kg: updateDonorProfileDto.weight_kg }
+        : {}),
+      ...(updateDonorProfileDto.city !== undefined
+        ? { city: updateDonorProfileDto.city }
+        : {}),
+      ...(updateDonorProfileDto.notify_radius_km !== undefined
+        ? {
+            notify_radius_km: updateDonorProfileDto.notify_radius_km,
+          }
+        : {}),
     };
 
     let profileId: string;
@@ -106,6 +129,22 @@ export class ProfilesService {
         rhesus: profileData.rhesus,
         location: profileData.location,
         last_donor: profileData.last_donor,
+        birth_date:
+          birthDate !== undefined
+            ? birthDate
+            : (existingProfile?.birth_date ?? null),
+        weight_kg:
+          updateDonorProfileDto.weight_kg !== undefined
+            ? updateDonorProfileDto.weight_kg
+            : (existingProfile?.weight_kg ?? null),
+        city:
+          updateDonorProfileDto.city !== undefined
+            ? updateDonorProfileDto.city
+            : (existingProfile?.city ?? null),
+        notify_radius_km:
+          updateDonorProfileDto.notify_radius_km !== undefined
+            ? updateDonorProfileDto.notify_radius_km
+            : (existingProfile?.notify_radius_km ?? null),
         eligibility: {
           is_eligible: eligibility.isEligible,
           remaining_days: eligibility.remainingDays,


### PR DESCRIPTION
## Summary

- Add optional donor birth date
- Add optional donor weight
- Add optional donor city
- Add optional notification radius
- Persist new fields through `PATCH /profiles/me`
- Return new fields through `GET /profiles/me`
- Preserve existing values when optional fields are omitted
- Allow fields to be cleared with `null`
- Limit notification radius to 20 km

## Verification

- `npm run build` ✅
- `npm test -- --runInBand` ✅
- Targeted ESLint check ✅
- New fields saved through PATCH ✅
- New fields returned through GET ✅
- Omitted fields preserve existing values ✅
- Nullable values verified ✅
- Invalid birth date → 400 ✅
- Invalid weight → 400 ✅
- Radius above 20 km → 400 ✅
- Unknown property → 400 ✅

## Scope

B-A1 only. Existing fields, endpoints, enums, response envelope,
and eligibility behavior remain unchanged.