### PR TITLE
fix(B-E3): add donor profile statistics

### DIFF
--- a/backend/src/profiles/profiles.module.ts
+++ b/backend/src/profiles/profiles.module.ts
@@ -4,9 +4,14 @@ import { AuthModule } from '../auth/auth.module';
 import { UserProfile } from './entities/user-profile.model';
 import { ProfilesController } from './profiles.controller';
 import { ProfilesService } from './profiles.service';
+import { Request } from '../requests/entities/request.model';
+import { User } from '../users/entities/user.model';
 
 @Module({
-  imports: [MongoloquentModule.forFeature([UserProfile]), AuthModule],
+  imports: [
+    MongoloquentModule.forFeature([UserProfile, Request, User]),
+    AuthModule,
+  ],
   controllers: [ProfilesController],
   providers: [ProfilesService],
 })

--- a/backend/src/profiles/profiles.service.ts
+++ b/backend/src/profiles/profiles.service.ts
@@ -8,12 +8,20 @@ import { ObjectId } from 'mongodb';
 import { calculateDonorEligibility } from '../common/helpers/donor-eligibility.helper';
 import { UpdateDonorProfileDto } from './dto/update-donor-profile.dto';
 import { UserProfile } from './entities/user-profile.model';
+import { Request } from '../requests/entities/request.model';
+import { User } from '../users/entities/user.model';
 
 @Injectable()
 export class ProfilesService {
   constructor(
     @InjectModel(UserProfile)
     private readonly userProfileModel: UserProfile,
+
+    @InjectModel(Request)
+    private readonly requestModel: Request,
+
+    @InjectModel(User)
+    private readonly userModel: User,
   ) {}
 
   async getForDonor(userId: string) {
@@ -30,6 +38,18 @@ export class ProfilesService {
     }
 
     const eligibility = calculateDonorEligibility(profile.last_donor);
+
+    const [completedRequests, user] = await Promise.all([
+      this.requestModel
+        .where('user_Profiles_id', profile._id)
+        .where('status', 'done')
+        .get(),
+      this.userModel.where('_id', profile.user_id).first(),
+    ]);
+
+    const memberSinceYear = user?.created_at
+      ? user.created_at.getUTCFullYear()
+      : null;
 
     return {
       success: true,
@@ -48,6 +68,10 @@ export class ProfilesService {
           is_eligible: eligibility.isEligible,
           remaining_days: eligibility.remainingDays,
           eligible_at: eligibility.eligibleAt,
+        },
+        stats: {
+          total_donations: completedRequests.length,
+          member_since_year: memberSinceYear,
         },
       },
     };


### PR DESCRIPTION
## Summary

- Augment `GET /profiles/me` with donor statistics
- Count completed requests as total donations
- Return membership year from user creation date
- Preserve all existing profile and eligibility fields

## Verification

- `npm run build` ✅
- `npm test -- --runInBand` ✅
- Targeted ESLint check ✅
- Donor without completed requests returns 0 ✅
- Completed request count matches `/requests/me?status=done` ✅
- Registered and confirmed requests are excluded ✅
- Membership year matches `users.created_at` ✅
- Existing response fields remain unchanged ✅

## Scope

B-E3 only. Additive response change; no model, endpoint, enum,
or existing response field was removed or renamed.