### PR TITLE
fix(B-E4): add facility profile endpoint

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -10,6 +10,7 @@ import { ProfilesModule } from './profiles/profiles.module';
 import { RequestsModule } from './requests/requests.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { DemoSeedModule } from './seeds/demo-seed.module';
+import { HospitalsModule } from './hospitals/hospitals.module';
 
 @Module({
   imports: [
@@ -38,6 +39,7 @@ import { DemoSeedModule } from './seeds/demo-seed.module';
     RequestsModule,
     NotificationsModule,
     DemoSeedModule,
+    HospitalsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/hospitals/hospitals.controller.ts
+++ b/backend/src/hospitals/hospitals.controller.ts
@@ -1,0 +1,23 @@
+import { Controller, Get, Req, UseGuards } from '@nestjs/common';
+import type { Request } from 'express';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import type { AuthenticatedUser } from '../auth/interfaces/jwt-payload.interface';
+import { HospitalsService } from './hospitals.service';
+
+interface AuthenticatedRequest extends Request {
+  user: AuthenticatedUser;
+}
+
+@Controller('hospitals')
+export class HospitalsController {
+  constructor(private readonly hospitalsService: HospitalsService) {}
+
+  @Get('me')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('facility')
+  getMine(@Req() request: AuthenticatedRequest) {
+    return this.hospitalsService.getForFacility(request.user.userId);
+  }
+}

--- a/backend/src/hospitals/hospitals.module.ts
+++ b/backend/src/hospitals/hospitals.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { MongoloquentModule } from '@mongoloquent/nestjs';
+import { AuthModule } from '../auth/auth.module';
+import { Blood } from '../bloods/entities/blood.model';
+import { Request } from '../requests/entities/request.model';
+import { Hospital } from './entities/hospital.model';
+import { HospitalsController } from './hospitals.controller';
+import { HospitalsService } from './hospitals.service';
+
+@Module({
+  imports: [
+    MongoloquentModule.forFeature([Hospital, Blood, Request]),
+    AuthModule,
+  ],
+  controllers: [HospitalsController],
+  providers: [HospitalsService],
+})
+export class HospitalsModule {}

--- a/backend/src/hospitals/hospitals.service.ts
+++ b/backend/src/hospitals/hospitals.service.ts
@@ -1,0 +1,89 @@
+import {
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { InjectModel } from '@mongoloquent/nestjs';
+import { ObjectId } from 'mongodb';
+import { Blood } from '../bloods/entities/blood.model';
+import { Request } from '../requests/entities/request.model';
+import { Hospital } from './entities/hospital.model';
+
+@Injectable()
+export class HospitalsService {
+  constructor(
+    @InjectModel(Hospital)
+    private readonly hospitalModel: Hospital,
+
+    @InjectModel(Blood)
+    private readonly bloodModel: Blood,
+
+    @InjectModel(Request)
+    private readonly requestModel: Request,
+  ) {}
+
+  async getForFacility(userId: string) {
+    if (!ObjectId.isValid(userId)) {
+      throw new UnauthorizedException('Invalid authenticated user');
+    }
+
+    const hospital = await this.hospitalModel
+      .where('user_id', new ObjectId(userId))
+      .first();
+
+    if (!hospital) {
+      throw new NotFoundException(
+        'Hospital profile was not found for this facility',
+      );
+    }
+
+    const bloods = await this.bloodModel
+      .where('hospitals_id', hospital._id)
+      .get();
+
+    const requestCollections = await Promise.all(
+      Array.from(bloods).map((blood) =>
+        this.requestModel.where('bloods_id', blood._id).get(),
+      ),
+    );
+
+    const requests = requestCollections.flatMap((collection) =>
+      Array.from(collection),
+    );
+
+    const doneCount = requests.filter(
+      (request) => request.status === 'done',
+    ).length;
+
+    const confirmedCount = requests.filter(
+      (request) => request.status === 'confirmed',
+    ).length;
+
+    const attendedOrConfirmed = doneCount + confirmedCount;
+
+    const attendanceRate =
+      attendedOrConfirmed === 0
+        ? 0
+        : Math.round((doneCount / attendedOrConfirmed) * 100);
+
+    return {
+      success: true,
+      data: {
+        id: hospital._id.toString(),
+        hospital_name: hospital.hospital_name,
+        code: hospital.code ?? null,
+        address: hospital.address ?? null,
+        unit_donor: hospital.unit_donor ?? null,
+        pic_name: hospital.pic_name ?? null,
+        contact: hospital.contact ?? null,
+        hospital_type: hospital.hospital_type ?? null,
+        isVerified: hospital.isVerified,
+        location: hospital.location,
+        stats: {
+          total_collected: doneCount,
+          attendance_rate: attendanceRate,
+        },
+      },
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- Add `GET /hospitals/me` for authenticated facilities
- Return additive hospital profile fields
- Resolve hospital ownership from JWT user
- Add total collected statistic
- Add attendance rate statistic
- Preserve existing hospital model fields and endpoints

## Verification

- `npm run build` ✅
- `npm test -- --runInBand` ✅
- Targeted ESLint check ✅
- Facility profile → 200 ✅
- Demo hospital fields returned ✅
- Total collected verified ✅
- Attendance rate verified ✅
- Facility without hospital → 404 ✅
- Without token → 401 ✅
- Donor token → 403 ✅

## Scope

B-E4 only. Additive endpoint; no existing field, endpoint, enum,
or response structure was removed or renamed.